### PR TITLE
Bug fixed.

### DIFF
--- a/src/esg/security/myproxy/GSSICredentialConnection.java
+++ b/src/esg/security/myproxy/GSSICredentialConnection.java
@@ -137,7 +137,7 @@ public class GSSICredentialConnection {
 	private String username;
 	private String password;
 	private String host;
-	private int port = 7512;	//default
+	private int port = 0;
 	private String caDirectory;
 
 


### PR DESCRIPTION
Bug info: Host and port were always overwritten with environment variables MYPROXY_SERVER and MYPROXY_SERVER_PORT when they had been obtained through openid (--openid option) or through properties file .MyProxyLogon

This error occurs when the values of env variables (MYPROXY_SERVER and MYPROXY_SERVER_PORT) are set and have different values than the values retrieved by openID.

Ex:
This command (that is used in the ESGF wget script):
java -Djavax.net.ssl.trustStore=/oceano/gmeteo/users/username/.esg/esg-truststore.ts -Djavax.net.ssl.trustStorePassword=changeit -jar /oceano/gmeteo/users/terryk/.esg/getcert.jar --openid https://pcmdi9.llnl.gov/esgf-idp/openid/username -P password --output /tmp/x509up_u15149 -d

returned:

Connection: username:[none]@MYPROXY_SERVER:MYPROXY_SERVER_PORT

> X509_CERT_DIR: /oceano/gmeteo/users/terryk/.esg/certificates
> MyProxy get failed. [Caused by: connect timed out]

because in this case MYPROXY_SERVER env is used by another software, and that's why does not match the OpenID host.
