### PR TITLE
Avoid SSLHandshakeException in JVM's < 7

### DIFF
--- a/src/esg/security/myproxy/CredentialConnection.java
+++ b/src/esg/security/myproxy/CredentialConnection.java
@@ -13,14 +13,9 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
-import java.net.Socket;
-import java.net.SocketAddress;
 import java.net.URL;
 import java.net.URLConnection;
-import java.net.UnknownHostException;
 import java.security.GeneralSecurityException;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
@@ -31,8 +26,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
-
-import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
@@ -51,8 +44,6 @@ import javax.xml.xpath.XPathFactory;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.w3c.dom.Document;
-
-import com.sun.net.ssl.SSLContext;
 
 import edu.uiuc.ncsa.MyProxy.MyProxyLogon;
 


### PR DESCRIPTION
If SSLHandshakeException is raised, SSLv3 and SSLv2Hello protocols are removed and then retry the
connection.

The idea comes from: http://www.oracle.com/technetwork/java/javase/documentation/cve-2014-3566-2342133.html. Specifically from this part:
- To dynamically remove SSLv3 from the list of enabled protocols, use the following code snippet:
      SSLSocket sslSocket = sslSocketFactory.createSocket(...);
  
  ```
  // Strip "SSLv3" from the current enabled protocols.
  String[] protocols = sslSocket.getEnabledProtocols();
  Set<String> set = new HashSet<>();
  for (String s : protocols) {
       if (s.equals("SSLv3") || s.equals("SSLv2Hello")) {
          continue;
      }
      set.add(s);
  }
  sslSocket.setEnabledProtocols(set.toArray(new String[0]));
  ```
