### PR TITLE
Avoid SSLHandshakeException in JVM's < 7

### DIFF
--- a/src/esg/security/myproxy/CredentialConnection.java
+++ b/src/esg/security/myproxy/CredentialConnection.java
@@ -13,14 +13,9 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
-import java.net.Socket;
-import java.net.SocketAddress;
 import java.net.URL;
 import java.net.URLConnection;
-import java.net.UnknownHostException;
 import java.security.GeneralSecurityException;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
@@ -31,8 +26,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
-
-import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
@@ -51,8 +44,6 @@ import javax.xml.xpath.XPathFactory;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.w3c.dom.Document;
-
-import com.sun.net.ssl.SSLContext;
 
 import edu.uiuc.ncsa.MyProxy.MyProxyLogon;
 

--- a/src/esg/security/myproxy/CredentialConnection.java
+++ b/src/esg/security/myproxy/CredentialConnection.java
@@ -1,5 +1,7 @@
 package esg.security.myproxy;
 
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -7,19 +9,33 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
+import java.net.Socket;
+import java.net.SocketAddress;
 import java.net.URL;
 import java.net.URLConnection;
+import java.net.UnknownHostException;
 import java.security.GeneralSecurityException;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
 
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
@@ -35,6 +51,8 @@ import javax.xml.xpath.XPathFactory;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.w3c.dom.Document;
+
+import com.sun.net.ssl.SSLContext;
 
 import edu.uiuc.ncsa.MyProxy.MyProxyLogon;
 
@@ -208,13 +226,83 @@ public class CredentialConnection {
         // try to parse the url (MalformedURLException)
         URL url = new URL(oid);
         
-        // try to get the page (IOException if it fails)
-        URLConnection conn = url.openConnection();
-//        if (conn instanceof HttpsURLConnection) {
-//        	((HttpsURLConnection)conn).setSSLSocketFactory(factory);
-//        	((HttpsURLConnection)conn).setHostnameVerifier(hostname_verifier);
-//        }
-        InputStream in = conn.getInputStream();
+        // try to get the page (IOException if it fails
+        InputStream in=null;
+        try{
+        	URLConnection conn = url.openConnection();
+        	in = conn.getInputStream();
+        }catch (SSLHandshakeException e){
+        	
+        	LOG.warn("SSLHandshakeException, removing SSLv3 and SSLv2Hello protocols");
+        	try {
+
+        		SSLSocketFactory sslSocketFactory = (SSLSocketFactory) SSLSocketFactory.getDefault();
+        		SSLSocket sslSocket = (SSLSocket) sslSocketFactory.createSocket(url.getHost(), 443);
+
+        		// Strip "SSLv3" from the current enabled protocols.
+        		String[] protocols = sslSocket.getEnabledProtocols();
+        		Set<String> set = new HashSet<String>();
+        		for (String s : protocols) {
+        			if (s.equals("SSLv3") || s.equals("SSLv2Hello")) {
+        				continue;
+        			}
+        			set.add(s);
+        		}
+        		sslSocket.setEnabledProtocols(set.toArray(new String[0]));
+
+        		//get openID xml
+        		PrintWriter out = new PrintWriter(
+        				new OutputStreamWriter(
+        						sslSocket.getOutputStream()));
+        		out.println("GET " + url.toString() + " HTTP/1.1");
+        	    out.println();
+        		out.flush();
+
+        		//read openid url content
+        		try {
+        			in = sslSocket.getInputStream();
+        			final BufferedReader reader = new BufferedReader(
+        					new InputStreamReader(in));
+        			
+        			//read headers
+        			boolean head=true;
+        			int headLen = 0;
+        			int contentLen=0;
+        			String line = null;
+        			line = reader.readLine();
+        			
+        			while (head==true & line!=null) {
+        				if(head){
+        					headLen = headLen+line.length();
+        					if(line.trim().equals("")){
+        						head=false;
+        					}else{
+        						String[] headers = line.trim().split(" ");
+        						if(headers[0].equals("Content-Length:")){
+        							contentLen = Integer.parseInt(headers[1]);
+        						}
+                				line = reader.readLine();
+        					}
+        				}
+        			}
+        			
+        			//read content
+        			char[] buffContent = new char[contentLen];
+        			reader.read(buffContent);
+                    reader.close();
+                    
+                    //make inpuStream for the content
+                    String content = new String(buffContent);
+            		in = new ByteArrayInputStream(content.getBytes());
+            		
+                } catch (final Exception e1) {
+                    e1.printStackTrace();
+                }
+        	} catch (IOException e1) {
+            	System.err.println("Can't parse OpenID: " + e.getMessage());
+        	}
+
+        }
 
         try {
             // now get the info we need
@@ -459,5 +547,5 @@ public class CredentialConnection {
 			e.printStackTrace();
 		}
 	}
-
+	
 }


### PR DESCRIPTION
If SSLHandshakeException is raised, SSLv3 and SSLv2Hello protocols are removed and then retry the
connection.

The idea comes from: http://www.oracle.com/technetwork/java/javase/documentation/cve-2014-3566-2342133.html. Specifically from this part:

    //To dynamically remove SSLv3 from the list of enabled protocols, use the following code snippet:
    SSLSocket sslSocket = sslSocketFactory.createSocket(...);

    // Strip "SSLv3" from the current enabled protocols.
    String[] protocols = sslSocket.getEnabledProtocols();
    Set<String> set = new HashSet<>();
    for (String s : protocols) {
         if (s.equals("SSLv3") || s.equals("SSLv2Hello")) {
            continue;
        }
        set.add(s);
    }
    sslSocket.setEnabledProtocols(set.toArray(new String[0]));